### PR TITLE
Make sur system-wide binaries are available in both /bin and /usr/bin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ ARG BASE_IMAGE
 FROM $BASE_IMAGE AS builder
 
 RUN apt-get update && apt-get install -y jq curl busybox
-RUN mkdir /emptydir
+RUN mkdir -p /tmpdir/tmp && chmod -R g=u /tmpdir/tmp
 
 # Create symlinks to busybox to provide common Unix utilities (see https://busybox.net/FAQ.html#getting_started)
 # Create symlink to /usr/bin which will be copied to /bin
@@ -112,7 +112,7 @@ COPY --from=builder /copied_zulu /usr/lib/jvm/zulu
 
 COPY --from=builder /etc/ssl/certs/ /etc/ssl/certs/
 
-COPY --from=builder /emptydir /tmp
+COPY --from=builder /tmpdir/ /
 
 ENV PATH="${PATH}:/usr/lib/jvm/zulu/bin/"
 


### PR DESCRIPTION
Motivation:

- Scripts generated by sbt native packager use /usr/bin/env in the shebang, so we want env to be available at that path.
- Common practice for many Linux distributions seems to be to install all system-wide binaries to /usr/bin, and link from /bin to /usr/bin (rather than distinguishing between the two).

Modifications:

- Copy binaries to /usr/bin instead of /bin
- Add a symbolic link from /bin to /usr/bin

Result:

Binaries can be launched with either common hardcoded paths (/usr/bin/... or /bin/...), as well as from the PATH.