### PR TITLE
chore: Add java 21 image, switch latest to java 21, CLD-3868, CLD-3869

### DIFF
--- a/.github/workflows/base_images.yml
+++ b/.github/workflows/base_images.yml
@@ -12,7 +12,7 @@ jobs:
     name: DockerHub
     strategy:
       matrix:
-        java: [8, 11, 17, 20]
+        tag: [8, 11, 17, 21, latest]
         include:
           - tag: 8
             java: 8
@@ -20,8 +20,10 @@ jobs:
             java: 11
           - tag: 17
             java: 17
+          - tag: 21
+            java: 21
           - tag: latest
-            java: 20
+            java: 21
     runs-on: ubuntu-latest
     timeout-minutes: 10
     env:


### PR DESCRIPTION
Motivation:

Java 21 is out. As it is a LTS, we want to:

- Add a dedicated 21 image
- Switch the latest tag to 21

Modification:

- It was simplier to use tag as a matrix key instead of java given the circumstances