### PR TITLE
chore: drop Java 8 from build matrix

### DIFF
--- a/.github/workflows/base_images.yml
+++ b/.github/workflows/base_images.yml
@@ -12,10 +12,8 @@ jobs:
     name: DockerHub
     strategy:
       matrix:
-        tag: [8, 11, 17, 21, latest]
+        tag: [11, 17, 21, latest]
         include:
-          - tag: 8
-            java: 8
           - tag: 11
             java: 11
           - tag: 17


### PR DESCRIPTION
We no longer support Java 8