### PR TITLE
Remove Java 11 and Java 17 from the build matrix

### DIFF
--- a/.github/workflows/base_images.yml
+++ b/.github/workflows/base_images.yml
@@ -12,12 +12,8 @@ jobs:
     name: DockerHub
     strategy:
       matrix:
-        tag: [11, 17, 21, latest]
+        tag: [21, latest]
         include:
-          - tag: 11
-            java: 11
-          - tag: 17
-            java: 17
           - tag: 21
             java: 21
           - tag: latest


### PR DESCRIPTION
Motivation:

We've stopped updating our certified images for Java 11 and 17 and we currently only use Java 21 and "latest" internally.